### PR TITLE
Cleanup jshint warnings

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -761,7 +761,7 @@ function packagesMeanJson(source) {
 
     for (var dep in data.dependencies) {
       shell.cd(process.cwd());
-      shell.exec('node node_modules/meanio/bin/mean-install ' + dep + '@' + data.dependencies[dep]);
+      shell.exec('node node_modules/meanio/bin/mean-install ' + dep + '@' + data.dependencies[dep], console.log);
     }
   });
 


### PR DESCRIPTION
grunt is blocked on jshint warnings unless those issues are cleared.
