### PR TITLE
fixing error handling on mean.serve()

### DIFF
--- a/lib/mean.js
+++ b/lib/mean.js
@@ -50,10 +50,33 @@ Meanio.prototype.serve = function(options, callback) {
       // Bootstrap Models, Dependencies, Routes and the app as an express app
       var app = require('./bootstrap')(options, database);
 
+      var readyApp = function() {
+
+        findModules(function() {
+          enableModules();
+        });
+
+        Meanio.Singleton.aggregate('js', null);
+
+        Meanio.Singleton.name = config.app.name;
+        Meanio.Singleton.app = app;
+
+        Meanio.Singleton.menus = new Meanio.Singleton.Menus();
+
+        callback(app, config);
+
+      };
+
       // Listen on http.port (or port as fallback for old configs)
       var httpServer = http.createServer(app);
       Meanio.Singleton.register('http', httpServer);
-      httpServer.listen(config.http ? config.http.port : config.port, config.hostname);
+      httpServer.listen(config.http ? config.http.port : config.port, config.hostname, undefined, readyApp);
+
+      httpServer.on('error', function(err) {
+        console.error('Error: ' + err.syscall + ' ' + err.code);
+        console.error('**Could not create http server. Please ensure node server is running with correct user/permissions.**');
+        process.exit(1);
+      });
 
       if (config.https && config.https.port) {
         var httpsOptions = {
@@ -63,21 +86,15 @@ Meanio.prototype.serve = function(options, callback) {
 
         var httpsServer = https.createServer(httpsOptions, app);
         Meanio.Singleton.register('https', httpsServer);
-        httpsServer.listen(config.https.port);
+        httpsServer.listen(config.https.port, config.hostname, undefined, readyApp);
+
+        httpsServer.on('error', function(err) {
+          console.error('Error: ' + err.syscall + ' ' + err.code);
+          console.error('**Could not create https server. Please ensure node server is running with correct user/permissions.**');
+          process.exit(1);
+        });
       }
 
-      findModules(function() {
-        enableModules();
-      });
-
-      Meanio.Singleton.aggregate('js', null);
-
-      Meanio.Singleton.name = config.app.name;
-      Meanio.Singleton.app = app;
-
-      Meanio.Singleton.menus = new Meanio.Singleton.Menus();
-
-      callback(app, config);
     });
 
     Meanio.Singleton.active = true;


### PR DESCRIPTION
fixing error handling so that we're catching http or https listening failures due to unable to bind to address or other reasons, then exiting and making sure that the rest of the mean app doesnt keep running as mean.serve() is unable to complete the job
