### PR TITLE
Catch errors from uglify

### DIFF
--- a/lib/aggregation.js
+++ b/lib/aggregation.js
@@ -117,11 +117,18 @@ Aggregator.prototype.pushAggregatedData = function(ext, filename, data) {
 
     var code = this.options.global ? data.toString() + '\n' : '(function(){' + data.toString() + '})();';
 
+  try {
     var ugly = uglify.minify(code, {
       fromString: true,
       mangle: false
     });
-
+	}
+	catch (e) {
+	console.log("\n\nError in file " + filename + " on line " + e.line);
+	console.log(e.message);
+	throw e;
+	}
+	
     aggregated[group][ext].weights[filename] = {
       weight: weight,
       data: !this.debug ? ugly.code : code


### PR DESCRIPTION
Uglify's error messages can be pretty nonexistent at times. Catching them and then returning the actual messages from the stack trace helps a lot

e.g.

```
/node_modules/meanio/node_modules/uglify-js/lib/parse.js:197
    throw new JS_Parse_Error(message, line, col, pos);
          ^
Error
    at new JS_Parse_Error (/node_modules/meanio/node_modules/uglify-js/lib/parse.js:189:18)
    at js_error (/node_modules/meanio/node_modules/uglify-js/lib/parse.js:197:11)
```

becomes:

```
Error in file /packages/system/public/controllers/index.js on line 103
Unexpected token punc «)», expected punc «,»

/node_modules/meanio/lib/aggregation.js:117
    throw e;
          ^
Error
    at new JS_Parse_Error (/node_modules/meanio/node_modules/uglify-js/lib/parse.js:189:18
```
