### PR TITLE
JSLint ^ Read only ignore for exports

### DIFF
--- a/lib/mean.js
+++ b/lib/mean.js
@@ -114,4 +114,6 @@ Meanio.prototype.chainware = {
 (require('./aggregation'))(Meanio);
 (require('./db'))(Meanio);
 
+/*global exports:true*/
 module.exports = exports = new Meanio();
+/*global exports:false*/


### PR DESCRIPTION
My Webstorm / jshint is flagging this...

https://github.com/jshint/jshint/issues/480
