### PR TITLE
Decoupling DB Library from Modules Library

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,3 +37,4 @@ If you become aware of any facts or circumstances related to the representation 
 * Andrija Petrovic {andrija-hers}
 * John Morris {spxis} 
 * Liran Tal {lirantal}
+* Jay Merrifield {fracmak}

--- a/lib/db.js
+++ b/lib/db.js
@@ -110,7 +110,7 @@ function supportDB(Meanio) {
     });
   };
 
-  Meanio.createModels = function () {
+  Meanio.Singleton.events.on('modulesEnabled', function() {
     for (var db in lazyModelsMap) {
       for (var model in lazyModelsMap[db]) {
         var rec = lazyModelsMap[db][model];
@@ -127,7 +127,7 @@ function supportDB(Meanio) {
       }
     }
     Meanio.Singleton.events.emit('lazy_models_ready');
-  };
+  });
 
   Meanio.applyModels = function (model_register) {
     for (var i in model_register) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -3,7 +3,8 @@
 var mongoose = require ('mongoose'),
   Q = require('q'),
   Schema = mongoose.Schema,
-  _ = require('lodash');
+  _ = require('lodash'),
+  util = require('./util');
 
 function filterDBAliases (v) {
   return mongoose.alias_MEANIODB_exists(v);
@@ -109,6 +110,13 @@ function registerModels (model_register) {
   }
 }
 
+function requireModel (path) {
+  var mdl = require(path);
+  if (mdl.register) {
+    registerModels(mdl.register);
+  }
+}
+
 function bindIndices (s, i) {
   s.index(i);
 }
@@ -154,10 +162,9 @@ function supportDB(Meanio) {
     loadLazyModels();
   });
 
-  Meanio.Singleton.events.on('modelFound', function(mdl){
-    if (mdl.register) {
-      registerModels(mdl.register);
-    }
+  Meanio.Singleton.events.on('moduleFound', function(module){
+    // bootstrap models
+    util.walk(module.modulePath('server'), 'model', null, requireModel);
   });
 }
 module.exports = supportDB;

--- a/lib/db.js
+++ b/lib/db.js
@@ -69,6 +69,46 @@ function createModelStructure (schema, model, collection, db) {
   if (schema.virtual) mc.virtual.push (schema.virtual);
 }
 
+function loadLazyModels () {
+  for (var db in lazyModelsMap) {
+    for (var model in lazyModelsMap[db]) {
+      var rec = lazyModelsMap[db][model];
+      //console.log('for db', db,' model ',model, 'is about to be created:',rec);
+      var s = new Schema(rec.fields, rec.options);
+      s.methods = rec.methods;
+      s.statics = rec.statics;
+      rec.virtual.forEach(bindVirtuals.bind(null, s));
+      rec.pre.forEach(bindHook.bind(null, s, 'pre'));
+      rec.post.forEach(bindHook.bind(null, s, 'post'));
+      rec.indices.forEach(bindIndices.bind(null, s));
+      applyModels(s, model, rec.collection, db);
+    }
+  }
+}
+
+function registerModels (model_register) {
+  for (var i in model_register) {
+    var itm = model_register[i];
+    if (!itm.schema) {
+      throw 'No schema in reqister model request, can not move on ...';
+    }
+    if (!itm.model) {
+      throw 'No model in register model request, can not move on ...';
+    }
+    if (!itm.dbs || itm.dbs.length === 0) {
+      itm.dbs = ['default'];
+    }
+    if (itm.schema instanceof mongoose.Schema) {
+      ///filter out eventual duplicates in dbs array and nonexisting aliases as well
+      _.uniq(itm.dbs.filter(filterDBAliases)).forEach(applyModels.bind(null, itm.schema, itm.model, itm.collection));
+      continue;
+    }
+
+    //ok, now form structures for lazy model creation
+    itm.dbs.forEach( createModelStructure.bind(null, itm.schema, itm.model, itm.collection) );
+  }
+}
+
 function bindIndices (s, i) {
   s.index(i);
 }
@@ -111,45 +151,13 @@ function supportDB(Meanio) {
   };
 
   Meanio.Singleton.events.on('modulesEnabled', function() {
-    for (var db in lazyModelsMap) {
-      for (var model in lazyModelsMap[db]) {
-        var rec = lazyModelsMap[db][model];
-        //console.log('for db', db,' model ',model, 'is about to be created:',rec);
-        var s = new Schema(rec.fields, rec.options);
-        s.methods = rec.methods;
-        s.statics = rec.statics;
-        rec.virtual.forEach(bindVirtuals.bind(null, s));
-        rec.pre.forEach(bindHook.bind(null, s, 'pre'));
-        rec.post.forEach(bindHook.bind(null, s, 'post'));
-        rec.indices.forEach(bindIndices.bind(null, s));
-        var m = applyModels(s, model, rec.collection, db);
-        Meanio.Singleton.events.emit ('lazy_model_ready', {model: m, db: db});
-      }
-    }
-    Meanio.Singleton.events.emit('lazy_models_ready');
+    loadLazyModels();
   });
 
-  Meanio.applyModels = function (model_register) {
-    for (var i in model_register) {
-      var itm = model_register[i];
-      if (!itm.schema) {
-        throw 'No schema in reqister model request, can not move on ...';
-      }
-      if (!itm.model) {
-        throw 'No model in register model request, can not move on ...';
-      }
-      if (!itm.dbs || itm.dbs.length === 0) {
-        itm.dbs = ['default'];
-      }
-      if (itm.schema instanceof mongoose.Schema) {
-        ///filter out eventual duplicates in dbs array and nonexisting aliases as well
-        _.uniq(itm.dbs.filter(filterDBAliases)).forEach(applyModels.bind(null, itm.schema, itm.model, itm.collection));
-        continue;
-      }
-
-      //ok, now form structures for lazy model creation
-      itm.dbs.forEach( createModelStructure.bind(null, itm.schema, itm.model, itm.collection) );
+  Meanio.Singleton.events.on('modelFound', function(mdl){
+    if (mdl.register) {
+      registerModels(mdl.register);
     }
-  };
+  });
 }
 module.exports = supportDB;

--- a/lib/module.js
+++ b/lib/module.js
@@ -94,7 +94,6 @@ function supportModules(Meanio){
       Meanio.Singleton.get(name);
       remaining--;
       if (!remaining) {
-        Meanio.createModels();
         Meanio.Singleton.events.emit('modulesEnabled');
       }
     }

--- a/lib/module.js
+++ b/lib/module.js
@@ -85,7 +85,7 @@ function supportModules(Meanio){
     var name, remaining = 0;
     for (name in Meanio.modules) {
       remaining++;
-      require(modulePath(name, 'app.js'));
+      require(Meanio.Singleton.get(name).modulePath('app.js'));
     }
 
     for (name in Meanio.modules) {
@@ -99,24 +99,16 @@ function supportModules(Meanio){
     }
   }
 
-
-
-  function requireModel (path) {
-    var mdl = require(path);
-    Meanio.Singleton.events.emit('modelFound', mdl);
-  }
-
   function Module(name) {
     this.name = lowerCaseFirstLetter(name);
     this.menus = Meanio.Singleton.menus;
     this.config = Meanio.Singleton.config;
 
-    // bootstrap models
-    util.walk(modulePath(this.name, 'server'), 'model', null, requireModel);
+    Meanio.Singleton.events.emit('moduleFound', this);
   }
 
   Module.prototype.render = function(view, options, callback) {
-    swig.renderFile(modulePath(this.name, '/server/views/' + view + '.html'), options, callback);
+    swig.renderFile(this.modulePath('/server/views/' + view + '.html'), options, callback);
   };
 
   Module.prototype.setDefaultTemplate = function(template) {
@@ -126,7 +118,7 @@ function supportModules(Meanio){
   Module.prototype.routes = function() {
     var args = Array.prototype.slice.call(arguments);
     var that = this;
-    util.walk(modulePath(this.name, 'server'), 'route', 'middlewares', function(route) {
+    util.walk(this.modulePath('server'), 'route', 'middlewares', function(route) {
       require(route).apply(that, [that].concat(args));
     });
   };
@@ -200,9 +192,9 @@ function supportModules(Meanio){
 
   Meanio.prototype.Module = Module;
 
-  function modulePath(name, plus) {
-    return path.join(process.cwd(), Meanio.modules[name].source, name, plus);
-  }
+  Module.prototype.modulePath = function(plus) {
+    return path.join(process.cwd(), Meanio.modules[this.name].source, this.name, plus);
+  };
 
 }
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -103,7 +103,7 @@ function supportModules(Meanio){
 
   function requireModel (path) {
     var mdl = require(path);
-    if (mdl.register) {Meanio.applyModels(mdl.register);}
+    Meanio.Singleton.events.emit('modelFound', mdl);
   }
 
   function Module(name) {


### PR DESCRIPTION
Libraries should be isolated from each other unless absolutely necessary. The event emitter is a lot better way to communicate between the libraries. This removes Meanio.createModels and Meanio.applyModels functions and instead replaces them with listeners on the existing "modulesEnabled" event and introduces a new "moduleFound" event.

On a side note, is there a reason the lazy models are loaded on modulesEnabled instead of modulesFound? Seems like loading them there would cause fewer problems.
