### PR TITLE
replaced path.join with path.normalize and manual /

### DIFF
--- a/lib/aggregation.js
+++ b/lib/aggregation.js
@@ -97,7 +97,7 @@ Aggregator.prototype.readFile = function(ext, filepath) {
 
 Aggregator.prototype.processFileOfDirOfFiles = function(ext, filepath, file) {
   if (!this.libs && (file !== 'assets' && file !== 'tests')) {
-    this.readFile(ext, path.join(filepath, file));
+    this.readFile(ext, path.normalize(filepath + '/' +  file));
   }
 };
 
@@ -122,7 +122,6 @@ Aggregator.prototype.getRemoteCode = function(ext, asset) {
 Aggregator.prototype.pushAggregatedData = function(ext, filename, data) {
   var group = this.options.group || 'footer',
       weight = this.options.weight || 0;
-
   if(data){
     if (ext === 'js') {
 
@@ -205,7 +204,7 @@ function supportAggregate(Meanio) {
   Meanio.prototype.Module.prototype.aggregateAsset = function(type, asset, options) {
     options = options || {};
     if (!options.inline && !options.absolute && !options.url) {
-      asset = path.join(Meanio.modules[this.name].source, this.name, 'public/assets', type, asset);
+      asset = path.normalize(Meanio.modules[this.name].source + '/' + this.name + '/' + 'public/assets' + '/' + type + '/' + asset);
     }
     Meanio.aggregate(type, asset, options, Meanio.Singleton.config.clean);
   };
@@ -214,7 +213,7 @@ function supportAggregate(Meanio) {
     var config = Meanio.Singleton.config.clean;
     var aggregator = new Aggregator(options, false, config);
     for (var name in Meanio.modules) {
-      aggregator.readFiles(ext, path.join(process.cwd(), Meanio.modules[name].source, name.toLowerCase(), 'public'));
+      aggregator.readFiles(ext, path.normalize(process.cwd() + '/' + Meanio.modules[name].source + '/' + name.toLowerCase() + '/' + 'public'));
     }
   };
 
@@ -228,7 +227,7 @@ function supportAggregate(Meanio) {
     if (options.inline) return aggregator.addInlineCode(ext, asset);
     else if (options.url) return aggregator.getRemoteCode(ext, asset);
     else if (options.singlefile) return aggregator.processDirOfFile(ext, asset);
-    else return aggregator.readFile(ext, path.join(process.cwd(), asset));
+    else return aggregator.readFile(ext, path.normalize(process.cwd() + '/' +  asset));
   };
 
   Meanio.prototype.aggregate = Meanio.aggregate;


### PR DESCRIPTION
path.join creates paths with \ as separator in windows witch is a wrong
separator for a url.
i replaced the path.join with path.normalize and manual concating with /
as the separator
