### PR TITLE
fixes `menu` type, add icon support

### DIFF
--- a/lib/menu.js
+++ b/lib/menu.js
@@ -36,6 +36,7 @@ MenuItem.prototype.strip = function () {
     title:this.title,
     link: this.link,
     roles:this.roles,
+    icon: this.icon,
     submenus: this.submenus.map(mapDoStrip)
   };
 };
@@ -50,6 +51,7 @@ MenuItem.prototype.props = function () {
     name: this.name,
     title:this.title,
     link:this.link,
+    icon: this.icon,
     roles:this.roles
   };
 };
@@ -95,6 +97,7 @@ MenuItem.prototype.get = function (roles, path) {
     link : this.link || null,
     title:this.title || null,
     name : this.name || null,
+    icon : this.icon || null,
     submenus : this.submenus.map(get_get.bind(null, roles)).filter(remove_nulls),
   });
 };


### PR DESCRIPTION
### `menu` type support

As described by the documentation, and as generated by the scaffolding- the name of the property should be `menu` instead of `path`.
This PR is allow you to set `menu` or `path`.

``` js
  Investor.menus.add({
    title: 'investors manage',
    link: 'investors.admin',
    icon: 'mean-admin/assets/img/icons/settings.png',
    roles: ['admin'],
    menu: 'admin'
  });
```
### `icon` support

Also, this PR enable using the `icon` property(as used in the `mean-admin`)
