### PR TITLE
Synchronizing (de-asynchronizing) the core procedures

### DIFF
--- a/lib/aggregation.js
+++ b/lib/aggregation.js
@@ -88,27 +88,72 @@ Aggregator.prototype.processDirOfFile = function(ext, filepath, err, files) {
       this.processFileOfFile(ext, filepath);
     }
   }else{
-    fs.readFile(filepath, this.processFileOfFile.bind(this, ext, filepath));
+    try{
+      this.processFileOfFile(ext,filepath,null,fs.readFileSync(filepath));
+    }
+    catch(e){
+      console.error('Error in reading',filepath,':',e);
+    }
+    //fs.readFile(filepath, this.processFileOfFile.bind(this, ext, filepath));
   }
 };
 
 Aggregator.prototype.readFile = function(ext, filepath) {
-  fs.readdir(filepath, this.processDirOfFile.bind(this, ext, filepath));
+  try{
+    if(!fs.existsSync(filepath)){
+      return;
+    }
+    var stats = fs.statSync(filepath);
+    if(stats.isDirectory()){
+      this.processDirOfFile(ext,filepath,null,fs.readdirSync(filepath));
+    }else if(stats.isFile()){
+      this.processDirOfFile(ext,filepath,null,null);
+    }
+  }
+  catch(e){
+    console.error('readFile Error in reading dir',filepath,':',e);
+  }
+  //fs.readdir(filepath, this.processDirOfFile.bind(this, ext, filepath));
 };
 
-Aggregator.prototype.processFileOfDirOfFiles = function(ext, filepath, file) {
-  if (!this.libs && (file !== 'assets' && file !== 'tests')) {
-    this.readFile(ext, path.join(filepath, file));
+Aggregator.prototype.sortFSEntity = function(files,dirs,ext,filepath,fname){
+  var fp = path.join(filepath, fname);
+  var stats = fs.statSync(fp);
+  if(stats.isFile() && path.extname(fname) === '.' + ext){
+    files.push(fp);
   }
+  if(stats.isDirectory() && (!this.libs && (fname !== 'assets' && fname !== 'tests')) ){
+    dirs.push(fp);
+  }
+}
+
+Aggregator.prototype.handleDirFile = function(ext,filepath){
+  this.processFileOfFile(ext,filepath,null,fs.readFileSync(filepath));
+};
+
+Aggregator.prototype.drillDirectory = function(ext,filepath){
+  this.processDirOfFiles(ext,filepath,null,fs.readdirSync(filepath));
 };
 
 Aggregator.prototype.processDirOfFiles = function(ext, filepath, err, files) {
   if (err) return;
-  files.forEach(this.processFileOfDirOfFiles.bind(this, ext, filepath));
+  var _files = [], _dirs = [];
+  files.forEach(this.sortFSEntity.bind(this,_files,_dirs,ext,filepath));
+  _files.forEach(this.handleDirFile.bind(this,ext));
+  _dirs.forEach(this.drillDirectory.bind(this,ext));
 };
 
 Aggregator.prototype.readFiles = function(ext, filepath) {
-  fs.readdir(filepath, this.processDirOfFiles.bind(this, ext, filepath));
+  try{
+    if(!fs.existsSync(filepath)){
+      return;
+    }
+    this.processDirOfFiles(ext,filepath,null,fs.readdirSync(filepath));
+  }
+  catch(e){
+    console.error('Error in reading dir',filepath,':',e);
+  }
+  //fs.readdir(filepath, this.processDirOfFiles.bind(this, ext, filepath));
 };
 
 Aggregator.prototype.getRemoteCode = function(ext, asset) {

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -10,7 +10,7 @@ var express = require('express'),
 
 
 
-module.exports = function(Meanio) {
+module.exports = function(Meanio,callback) {
 
   var db = Meanio.Singleton.get('database').connection;
   var config = Meanio.Singleton.config.clean;
@@ -145,7 +145,7 @@ module.exports = function(Meanio) {
     httpsServer.listen(config.https.port);
   }
 
-  Meanio.Singleton.Module.bootstrapModules();
+  Meanio.Singleton.Module.bootstrapModules(callback);
 
   Meanio.Singleton.name = config.app.name;
   Meanio.Singleton.app = app;

--- a/lib/mean.js
+++ b/lib/mean.js
@@ -17,8 +17,8 @@ function doBootstrap (callback, err) {
   }
   Meanio.Singleton.config.loadSettings(function(){
     // Bootstrap Models, Dependencies, Routes and the app as an express app
-    require('./bootstrap')(Meanio);
-    callback(Meanio.Singleton.app, Meanio.Singleton.config.clean);
+    require('./bootstrap')(Meanio,callback.bind(null,Meanio.Singleton.app, Meanio.Singleton.config.clean));
+    //callback(Meanio.Singleton.app, Meanio.Singleton.config.clean);
   });
 }
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -81,7 +81,7 @@ function supportModules(Meanio){
     return deferred.resolve(Q.all(promises));
   }
 
-  function enableModules() {
+  function enableModules(callback) {
     var name, remaining = 0;
     for (name in Meanio.modules) {
       remaining++;
@@ -96,6 +96,7 @@ function supportModules(Meanio){
       if (!remaining) {
         Meanio.createModels();
         Meanio.Singleton.events.emit('modulesEnabled');
+        callback();
       }
     }
   }
@@ -195,8 +196,8 @@ function supportModules(Meanio){
     if (arguments.length === 1 && typeof arguments[0] === 'function') return getSettings(Package, this.name, arguments[0]);
 
   };
-  Module.bootstrapModules = function(){
-    findModules(enableModules);
+  Module.bootstrapModules = function(callback){
+    findModules(enableModules.bind(null,callback));
   };
 
   Meanio.prototype.Module = Module;


### PR DESCRIPTION
1. serve method of meanio now triggers the callback once all the modules have been enabled
2. all fs functions are now used in their Sync form (readdirSync, readFileSync), so that full control over aggregation is achieved
3. aggregation handles directory contents in a "files first, directories after" manner; that's necessary for aggregation of `public` directories of packages (crucial files have to go before the `controllers`, `services` and other directories)