### PR TITLE
Remove bower components from meanio to enable gzip

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -82,8 +82,6 @@ module.exports = function(Meanio,callback) {
     });
   });
 
-  app.use('/bower_components', express.static(config.root + '/bower_components'));
-
   Meanio.Singleton.events.on('modulesEnabled', function() {
 
     for (var name in Meanio.Singleton.modules) {


### PR DESCRIPTION
This line when put in config/express.js will allow it to be gzip enabled. Order of loading is important.