### PR TITLE
Fixed Module.render()

### DIFF
--- a/lib/core_modules/module/index.js
+++ b/lib/core_modules/module/index.js
@@ -159,7 +159,7 @@ function supportModules(Meanio){
   }
 
   Module.prototype.render = function(view, options, callback) {
-    swig.renderFile(modulePath(this.name, '/server/views/' + view + '.html'), options, callback);
+    swig.renderFile(this.loadedmodule.path('/server/views/') + view + '.html', options, callback);
   };
 
   Module.prototype.setDefaultTemplate = function(template) {


### PR DESCRIPTION
When testing /theme/example/render I found an error with Module.render. This fixed it for me, I don't know why it was modulePath before, because this function isn't defined. Below is the error I received while testing /theme/example/render:
```ReferenceError: modulePath is not defined
    at Module.render (/root/test/node_modules/meanio/lib/core_modules/module/index.js:162:21)
    at /root/test/packages/theme/server/routes/theme.js:19:11
    at Layer.handle [as handle_request] (/root/test/node_modules/meanio/lib/core_modules/server/node_modules/express/lib/router/layer.js:82:5)
    at next (/root/test/node_modules/meanio/lib/core_modules/server/node_modules/express/lib/router/route.js:110:13)
    at Route.dispatch (/root/test/node_modules/meanio/lib/core_modules/server/node_modules/express/lib/router/route.js:91:3)
    at Layer.handle [as handle_request] (/root/test/node_modules/meanio/lib/core_modules/server/node_modules/express/lib/router/layer.js:82:5)
    at /root/test/node_modules/meanio/lib/core_modules/server/node_modules/express/lib/router/index.js:267:22
    at Function.proto.process_params (/root/test/node_modules/meanio/lib/core_modules/server/node_modules/express/lib/router/index.js:321:12)
    at next (/root/test/node_modules/meanio/lib/core_modules/server/node_modules/express/lib/router/index.js:261:10)
    at SendStream.error (/root/test/node_modules/meanio/lib/core_modules/server/node_modules/express/node_modules/serve-static/index.js:107:7)```