### PR TITLE
Fixed default aggregate setting, fixes linnovate/mean#1282

### DIFF
--- a/lib/core_modules/module/index.js
+++ b/lib/core_modules/module/index.js
@@ -53,7 +53,7 @@ function findModulesDone (meanioinstance, app, defer) {
   var config = meanioinstance.config.clean;
   app.get('/_getModules',getModulesHandler.bind(null,meanioinstance));
 
-  if(config.aggregate){
+  if(config.aggregate !== false){
     var jqueryminmap = fs.readFileSync(config.root + '/bower_components/jquery/dist/jquery.min.map');
     app.get('/modules/jquery.min.map',jQueryMinMapHandler.bind(null,jqueryminmap));
     app.get('/modules/aggregated.js', aggregatedJSHandler.bind(null,meanioinstance));


### PR DESCRIPTION
Lack of an explicit "aggregate:true" in config was causing aggregation to be activated but the routes were not being defined.