### PR TITLE
Added optional md5 as suffix to css/js

### DIFF
--- a/lib/core_modules/module/aggregation.js
+++ b/lib/core_modules/module/aggregation.js
@@ -66,10 +66,11 @@ WeightedList.prototype.buildScalars = function(){
 WeightedList.prototype.addToScalars = function(content){
   if(!content){return;}
   if(content.src){
-    if(content.options.hash && content.hash)
+    if(content.options.hash && content.hash) {
       this.src.push(content.src + content.options.separator + content.hash);
-    else
+    } else {
       this.src.push(content.src);
+    }
   }
   if(content.data){
     if(this.data){
@@ -465,7 +466,7 @@ function supportAggregate(Meanio) {
     options.aggregate = Meanio.Singleton.config.clean.aggregate;
     options.debug = Meanio.Singleton.config.clean.debug;
     if(Meanio.Singleton.config.clean.assets) {
-      options.hash = Meanio.Singleton.config.clean.assets.hash == false ? false : true;
+      options.hash = Meanio.Singleton.config.clean.assets.hash === false ? false : true;
       options.separator = Meanio.Singleton.config.clean.assets.separator || '?v=';
     } else {
       options.hash = true;

--- a/lib/core_modules/module/aggregation.js
+++ b/lib/core_modules/module/aggregation.js
@@ -10,6 +10,7 @@ var fs = require('fs'),
   List = require('complex-list'),
   inherit = require('./inherit'),
   assetmanager = require('assetmanager'),
+  md5 = require('md5'),
   async = true;
 
 //Asset and subtypes represent css and js file (remote, inlines and files)
@@ -65,7 +66,10 @@ WeightedList.prototype.buildScalars = function(){
 WeightedList.prototype.addToScalars = function(content){
   if(!content){return;}
   if(content.src){
-    this.src.push(content.src);
+    if(content.options.hash && content.hash)
+      this.src.push(content.src + content.options.separator + content.hash);
+    else
+      this.src.push(content.src);
   }
   if(content.data){
     if(this.data){
@@ -87,6 +91,7 @@ var aggregated = {
 function Asset(src,options){
   this.src = src;
   this.options = options;
+  this.hash = null;
   if(!this.options.weight){
     this.options.weight=0;
   }
@@ -96,6 +101,7 @@ Asset.prototype.destroy = function(){
   this.data = null;
   this.options = null;
   this.src = null;
+  this.hash = null;
 };
 Asset.prototype.minifyData = function(stringdata){
   this.data = stringdata;
@@ -144,6 +150,8 @@ Asset.prototype.processStringData = function(stringdata){
     }else{
       console.log('but not, since data is of 0 length');
     }
+  } else if(this.options.hash) {
+    this.hash = md5(stringdata);
   }
   this.store();
 };
@@ -440,7 +448,7 @@ function supportAggregate(Meanio) {
     if (ext==='css' && group==='header'){
       rtl.push('/modules/rtl.css');
     }
-    
+
     if(ext==='css'){
       callback(group==='header' ? (aggregated.css ? aggregated.css.getSrc().concat(rtl) : []) : []);
       return;
@@ -456,13 +464,20 @@ function supportAggregate(Meanio) {
     options = options || {};
     options.aggregate = Meanio.Singleton.config.clean.aggregate;
     options.debug = Meanio.Singleton.config.clean.debug;
-    
+    if(Meanio.Singleton.config.clean.assets) {
+      options.hash = Meanio.Singleton.config.clean.assets.hash == false ? false : true;
+      options.separator = Meanio.Singleton.config.clean.assets.separator || '?v=';
+    } else {
+      options.hash = true;
+      options.separator = '?v=';
+    }
+
     var self = this;
     this.settings(function(err, settings) {
       if (settings &&
-          settings.settings &&
-          settings.settings.languages &&
-          settings.settings.currentLanguage) {
+        settings.settings &&
+        settings.settings.languages &&
+        settings.settings.currentLanguage) {
 
         var languages = settings.settings.languages;
         var currentLanguage = settings.settings.currentLanguage;

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "glob": "^4.0.3",
     "lazy-dependable": "latest",
     "lodash": "^2.4.1",
+    "md5": "latest",
     "mean-health": "~0.1.3",
     "morgan": "1.5.0",
     "q": "^1.0.1",


### PR DESCRIPTION
Related to linnovate/mean#1293

This supports an extra object on mean configs of: 
assets : {
  hash: true, // default
  separator: '?v=' // default
},

@liorkesos I'd appreciate input on config naming, and default settings, what you think makes sense in most cases and any problems you see with the approach.
@dazwin Try this out and see if it fulfills the caching portion of your issue.  We can look into extending this approach with liors suggestions in the issue for the cdn root.