### PR TITLE
Implement a retry capability when connecting to MongoDB

### DIFF
--- a/lib/core_modules/db/index.js
+++ b/lib/core_modules/db/index.js
@@ -3,7 +3,8 @@
 var mongoose = require ('mongoose'),
   Q = require('q'),
   Schema = mongoose.Schema,
-  _ = require('lodash');
+  _ = require('lodash'),
+  async = require('async');
 
 function filterDBAliases (v) {
   return mongoose.alias_MEANIODB_exists(v);
@@ -91,7 +92,15 @@ function bindHook (s, type, rec) {
 function onInstanceAndConfig(defer, meanioinstance, config, done) {
   var defaultConfig = config.clean;
   mongoose.set('debug', defaultConfig.mongoose && defaultConfig.mongoose.debug);
-  var database = mongoose.connect(defaultConfig.db || '', defaultConfig.dbOptions || {}, function(err) {
+  var retryOpts = defaultConfig.dbOptions && defaultConfig.dbOptions.retry || { times: 1, interval: 0 };
+  async.retry(retryOpts, function(callback) {
+    var database = mongoose.connect(defaultConfig.db || '', defaultConfig.dbOptions || {}, function(err) {
+      if (err)
+        console.error('Error:', err.message);
+        
+      callback(err, database);
+    });
+  }, function(err, database) {
     if (err) {
       console.error('Error:', err.message);
       return console.error('**Could not connect to MongoDB. Please ensure mongod is running and restart MEAN app.**');

--- a/lib/core_modules/db/index.js
+++ b/lib/core_modules/db/index.js
@@ -95,9 +95,10 @@ function onInstanceAndConfig(defer, meanioinstance, config, done) {
   var retryOpts = defaultConfig.dbOptions && defaultConfig.dbOptions.retry || { times: 1, interval: 0 };
   async.retry(retryOpts, function(callback) {
     var database = mongoose.connect(defaultConfig.db || '', defaultConfig.dbOptions || {}, function(err) {
-      if (err)
+      if (err) {
         console.error('Error:', err.message);
-        
+      }
+
       callback(err, database);
     });
   }, function(err, database) {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "shelljs": "latest",
     "stacksight": "latest",
     "swig": "^1.3.2",
-    "uglify-js": "^2.4.14"
+    "uglify-js": "^2.4.14",
+    "async": "^1.4.0"
   },
   "devDependencies": {
     "mocha": "^1.18.2",


### PR DESCRIPTION
This allows configuration of a retry loop when connecting to Mongo. You can configure as follows:

```
module.exports = {
  db: 'mongodb://' + (process.env.DB_PORT_27017_TCP_ADDR || 'localhost') + '/mean-dev',
  dbOptions: {
    retry: {
      times: 5,
      interval: 1000
    }
  },
  ...
```

Options are per [async.retry](https://github.com/caolan/async#retry) (interval is in ms). Default behavior is to not retry (i.e. current behavior).
