### PR TITLE
Added options to other aggregation paths

### DIFF
--- a/lib/core_modules/module/aggregation.js
+++ b/lib/core_modules/module/aggregation.js
@@ -388,7 +388,7 @@ function configureApp(Meanio,meanioinstance,defer,app){
     options.aggregate = Meanio.Singleton.config.clean.aggregate;
     options.debug = Meanio.Singleton.config.clean.debug;
     if(Meanio.Singleton.config.clean.assets) {
-      options.hash = Meanio.Singleton.config.clean.assets.hash == false ? false : true;
+      options.hash = Meanio.Singleton.config.clean.assets.hash === false ? false : true;
       options.separator = Meanio.Singleton.config.clean.assets.separator || '?v=';
     } else {
       options.hash = true;
@@ -477,7 +477,7 @@ function supportAggregate(Meanio) {
     options.aggregate = Meanio.Singleton.config.clean.aggregate;
     options.debug = Meanio.Singleton.config.clean.debug;
     if(Meanio.Singleton.config.clean.assets) {
-      options.hash = Meanio.Singleton.config.clean.assets.hash == false ? false : true;
+      options.hash = Meanio.Singleton.config.clean.assets.hash === false ? false : true;
       options.separator = Meanio.Singleton.config.clean.assets.separator || '?v=';
     } else {
       options.hash = true;
@@ -546,7 +546,7 @@ function supportAggregate(Meanio) {
     options.aggregate = Meanio.Singleton.config.clean.aggregate;
     options.debug = Meanio.Singleton.config.clean.debug;
     if(Meanio.Singleton.config.clean.assets) {
-      options.hash = Meanio.Singleton.config.clean.assets.hash == false ? false : true;
+      options.hash = Meanio.Singleton.config.clean.assets.hash === false ? false : true;
       options.separator = Meanio.Singleton.config.clean.assets.separator || '?v=';
     } else {
       options.hash = true;

--- a/lib/core_modules/module/aggregation.js
+++ b/lib/core_modules/module/aggregation.js
@@ -384,7 +384,18 @@ function aggregationRequestHandler(meanioinstance, req, res, next){
 
 function configureApp(Meanio,meanioinstance,defer,app){
   Meanio.modules.dependableConstructor().prototype.aggregatePackage = function(){
-    new PackageDir('js',path.join(process.cwd(), this.source), this.name, {aggregate:Meanio.Singleton.config.clean.aggregate});
+    var options = {};
+    options.aggregate = Meanio.Singleton.config.clean.aggregate;
+    options.debug = Meanio.Singleton.config.clean.debug;
+    if(Meanio.Singleton.config.clean.assets) {
+      options.hash = Meanio.Singleton.config.clean.assets.hash == false ? false : true;
+      options.separator = Meanio.Singleton.config.clean.assets.separator || '?v=';
+    } else {
+      options.hash = true;
+      options.separator = '?v=';
+    }
+
+    new PackageDir('js',path.join(process.cwd(), this.source), this.name, options);
     app.useStatic('/'+this.name, this.path('public'));
   };
   var assets = assetmanager.process({
@@ -466,7 +477,7 @@ function supportAggregate(Meanio) {
     options.aggregate = Meanio.Singleton.config.clean.aggregate;
     options.debug = Meanio.Singleton.config.clean.debug;
     if(Meanio.Singleton.config.clean.assets) {
-      options.hash = Meanio.Singleton.config.clean.assets.hash === false ? false : true;
+      options.hash = Meanio.Singleton.config.clean.assets.hash == false ? false : true;
       options.separator = Meanio.Singleton.config.clean.assets.separator || '?v=';
     } else {
       options.hash = true;
@@ -534,6 +545,13 @@ function supportAggregate(Meanio) {
     options = options||{};
     options.aggregate = Meanio.Singleton.config.clean.aggregate;
     options.debug = Meanio.Singleton.config.clean.debug;
+    if(Meanio.Singleton.config.clean.assets) {
+      options.hash = Meanio.Singleton.config.clean.assets.hash == false ? false : true;
+      options.separator = Meanio.Singleton.config.clean.assets.separator || '?v=';
+    } else {
+      options.hash = true;
+      options.separator = '?v=';
+    }
     Meanio.modules.traverse(moduleAggregateTraverser.bind(null,ext,options));
   };
 
@@ -544,6 +562,13 @@ function supportAggregate(Meanio) {
     options = options||{};
     options.aggregate = Meanio.Singleton.config.clean.aggregate;
     options.debug = Meanio.Singleton.config.clean.debug;
+    if(Meanio.Singleton.config.clean.assets) {
+      options.hash = Meanio.Singleton.config.clean.assets.hash === false ? false : true;
+      options.separator = Meanio.Singleton.config.clean.assets.separator || '?v=';
+    } else {
+      options.hash = true;
+      options.separator = '?v=';
+    }
     if (options.inline){
       switch(ext){
         case 'css':


### PR DESCRIPTION
I missed some paths that files get pushed into aggregation, so as @dazwin mentioned, some files weren't having the hashing options applied to them.  Now bower_components and files found through package aggregation also have hashes optionally applied.