### PR TITLE
Allows propagation of a weight value, to be used in implementation

### DIFF
--- a/lib/menu.js
+++ b/lib/menu.js
@@ -23,6 +23,7 @@ function MenuItem (options) {
   this.link = options.link;
   this.roles = options.roles;
   this.icon = options.icon;
+  this.weight = options.weight;
   this.submenus = options.submenus || [];
 }
 
@@ -37,6 +38,7 @@ MenuItem.prototype.strip = function () {
     link: this.link,
     roles:this.roles,
     icon: this.icon,
+    weight: this.weight,
     submenus: this.submenus.map(mapDoStrip)
   };
 };
@@ -52,6 +54,7 @@ MenuItem.prototype.props = function () {
     title:this.title,
     link:this.link,
     icon: this.icon,
+    weight: this.weight,
     roles:this.roles
   };
 };
@@ -98,6 +101,7 @@ MenuItem.prototype.get = function (roles, path) {
     title:this.title || null,
     name : this.name || null,
     icon : this.icon || null,
+    weight: this.weight || null,
     submenus : this.submenus.map(get_get.bind(null, roles)).filter(remove_nulls),
   });
 };


### PR DESCRIPTION
This just allows users to add a 'weight' value.  It isn't handled internally currently, just passed back to the app, but allows the controllers to use it, like:
```
    // Query menus added by modules. Only returns menus that user is allowed to see.
    function queryMenu(name, defaultMenu) {
      Menus.query({
        name: name,
        defaultMenu: defaultMenu
      }, function(menu) {
        menu.sort(function(a,b){return a.weight - b.weight});
        vm.menus[name] = menu;
      });
    }
```