### PR TITLE
Fix wrong calling subscribe function

### DIFF
--- a/lib/core_modules/server/ExpressEngine.js
+++ b/lib/core_modules/server/ExpressEngine.js
@@ -44,8 +44,11 @@ ExpressEngine.prototype.initApp = function() {
   this.app.use(cookieParser());
   // Request body parsing middleware should be above methodOverride
   this.app.use(expressValidator());
-  this.app.use(bodyParser.json());
+  this.app.use(bodyParser.json({
+    limit: '50mb'
+  }));
   this.app.use(bodyParser.urlencoded({
+    limit: '50mb',
     extended: true
   }));
   this.app.use(methodOverride());

--- a/lib/core_modules/sts/events.js
+++ b/lib/core_modules/sts/events.js
@@ -19,7 +19,7 @@ Events.prototype.publish = function(name, opts) {
 
 Events.prototype.subscribe = function(name, cb) {
     sts = require('./index')();
-    sts.subscribe(name, cb);
+    sts.events.subscribe(name, cb);
 };
 
 Events.prototype.design = function(data) {


### PR DESCRIPTION
This commit fixed the wrong calling subscribe function; the subscribe function was called from `sts` object, which was wrong. It should be called from `sts.events` object instead.