### PR TITLE
Fix to allow per-asset hash/separator settings

### DIFF
--- a/lib/core_modules/module/aggregation.js
+++ b/lib/core_modules/module/aggregation.js
@@ -476,12 +476,21 @@ function supportAggregate(Meanio) {
     options = options || {};
     options.aggregate = Meanio.Singleton.config.clean.aggregate;
     options.debug = Meanio.Singleton.config.clean.debug;
+
+    // Allow per-asset hash/separator to override config settings
+    var assetOptions = {};
     if(Meanio.Singleton.config.clean.assets) {
-      options.hash = Meanio.Singleton.config.clean.assets.hash === false ? false : true;
-      options.separator = Meanio.Singleton.config.clean.assets.separator || '?v=';
+      assetOptions.hash = Meanio.Singleton.config.clean.assets.hash === false ? false : true;
+      assetOptions.separator = Meanio.Singleton.config.clean.assets.separator || '?v=';
     } else {
-      options.hash = true;
-      options.separator = '?v=';
+      assetOptions.hash = true;
+      assetOptions.separator = '?v=';
+    }
+    if(typeof options.hash === 'undefined') {
+      options.hash = assetOptions.hash;
+    }
+    if(typeof options.separator === 'undefined') {
+      options.separator = assetOptions.separator;
     }
 
     if (Meanio.Singleton.config.clean.public && 


### PR DESCRIPTION
Fixes linnovate/mean#1327

Adding logic to parse the url and change the separator makes less sense since the separator is configurable, so just allowing per-asset hash and separator settings will allow it to be overridden in line with the aggregateAsset call.  Usage given the issue's case would be:
```
  myPackage.aggregateAsset('css', 'https://fonts.googleapis.com/css?family=Roboto+Condensed', {
    url: true,
    hash: false,
    weight: 1
  });
```
or the following would also make the url format valid
```
  myPackage.aggregateAsset('css', 'https://fonts.googleapis.com/css?family=Open+Sans', {
    url: true,
    separator: '&v=',
    weight: 1
  });
```