### PR TITLE
Fixed Issue https://github.com/linnovate/mean/issues/1169

### DIFF
--- a/lib/core_modules/server/ExpressEngine.js
+++ b/lib/core_modules/server/ExpressEngine.js
@@ -1,7 +1,6 @@
 var express = require('express'),
   cookieParser = require('cookie-parser'),
   expressValidator = require('express-validator'),
-  bodyParser = require('body-parser'),
   methodOverride = require('method-override'),
   http = require('http'),
   https = require('https'),
@@ -44,10 +43,6 @@ ExpressEngine.prototype.initApp = function() {
   this.app.use(cookieParser());
   // Request body parsing middleware should be above methodOverride
   this.app.use(expressValidator());
-  this.app.use(bodyParser.json());
-  this.app.use(bodyParser.urlencoded({
-    extended: true
-  }));
   this.app.use(methodOverride());
 
   // We are going to protect /api routes with JWT


### PR DESCRIPTION
Fixed the issue https://github.com/linnovate/mean/issues/1169. Where an error is throw about request entity been too large.

Added an enhancement to enable setting body size in the mean configuration. 