### PR TITLE
fix bug over SSL for mobile device when use CA certificate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,3 +38,4 @@ If you become aware of any facts or circumstances related to the representation 
 * John Morris {spxis} 
 * Liran Tal {lirantal}
 * Farhad Adeli {Exlord}
+* Rommel Juarez {juarez9j}

--- a/lib/core_modules/server/ExpressEngine.js
+++ b/lib/core_modules/server/ExpressEngine.js
@@ -128,7 +128,8 @@ ExpressEngine.prototype.beginBootstrap = function(meanioinstance, database) {
   if (config.https && config.https.port) {
     var httpsOptions = {
       key: fs.readFileSync(config.https.ssl.key),
-      cert: fs.readFileSync(config.https.ssl.cert)
+      cert: fs.readFileSync(config.https.ssl.cert),
+      ca: fs.readFileSync(config.https.ssl.ca)
     };
 
     var httpsServer = https.createServer(httpsOptions, app);


### PR DESCRIPTION

Now you configure your CA in the all.js ExpressEngine.js file but does not take such a configuration.
Some browsers are sencibles when no CA is used.