### PR TITLE
Add socket.io with multiple cluster's support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,3 +39,4 @@ If you become aware of any facts or circumstances related to the representation 
 * Liran Tal {lirantal}
 * Farhad Adeli {Exlord}
 * Rommel Juarez {juarez9j}
+* Kévin Berthommier {bertho-zero}

--- a/lib/core_modules/server/ExpressEngine.js
+++ b/lib/core_modules/server/ExpressEngine.js
@@ -10,7 +10,8 @@ var express = require('express'),
   errorHandler = require('errorhandler'),
   morgan = require('morgan'),
   passport = require('passport'),
-  expressJwt = require('express-jwt');
+  expressJwt = require('express-jwt'),
+  sticky = require('socketio-sticky-session');
 
 function ExpressEngine() {
   ServerEngine.call(this);
@@ -123,7 +124,11 @@ ExpressEngine.prototype.beginBootstrap = function(meanioinstance, database) {
   // Listen on http.port (or port as fallback for old configs)
   var httpServer = http.createServer(app);
   meanioinstance.register('http', httpServer);
-  httpServer.listen(config.http ? config.http.port : config.port);
+  if(config.clusterSticky) {
+    sticky(httpServer).listen(config.http ? config.http.port : config.port);
+  } else {
+    httpServer.listen(config.http ? config.http.port : config.port);
+  }
 
   if (config.https && config.https.port) {
     var httpsOptions = {
@@ -134,7 +139,11 @@ ExpressEngine.prototype.beginBootstrap = function(meanioinstance, database) {
 
     var httpsServer = https.createServer(httpsOptions, app);
     meanioinstance.register('https', httpsServer);
-    httpsServer.listen(config.https.port);
+    if(config.clusterSticky) {
+      sticky(httpsServer).listen(config.https.port);
+    } else {
+      httpServer.listen(config.https.port);
+    }
   }
 
   meanioinstance.name = config.app.name;

--- a/lib/core_modules/server/ExpressEngine.js
+++ b/lib/core_modules/server/ExpressEngine.js
@@ -124,7 +124,7 @@ ExpressEngine.prototype.beginBootstrap = function(meanioinstance, database) {
   // Listen on http.port (or port as fallback for old configs)
   var httpServer = http.createServer(app);
   meanioinstance.register('http', httpServer);
-  if(config.clusterSticky) {
+  if(config.clusterSticky && (process.env.NODE_ENV !== 'test') && (process.env.NODE_ENV !== 'development')) {
     sticky(httpServer).listen(config.http ? config.http.port : config.port);
   } else {
     httpServer.listen(config.http ? config.http.port : config.port);
@@ -139,7 +139,7 @@ ExpressEngine.prototype.beginBootstrap = function(meanioinstance, database) {
 
     var httpsServer = https.createServer(httpsOptions, app);
     meanioinstance.register('https', httpsServer);
-    if(config.clusterSticky) {
+    if(config.clusterSticky && (process.env.NODE_ENV !== 'test') && (process.env.NODE_ENV !== 'development')) {
       sticky(httpsServer).listen(config.https.port);
     } else {
       httpServer.listen(config.https.port);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "shelljs": "latest",
     "stacksight": "latest",
     "swig": "^1.3.2",
-    "uglify-js": "^2.4.14"
+    "uglify-js": "^2.4.14",
+    "socketio-sticky-session": "^0.4.1"
   },
   "devDependencies": {
     "mocha": "^1.18.2",

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     "request": "^2.47.0",
     "rtlcss": "^1.6.1",
     "shelljs": "latest",
+    "socketio-sticky-session": "^0.4.1",
     "stacksight": "latest",
     "swig": "^1.3.2",
-    "uglify-js": "^2.4.14",
-    "socketio-sticky-session": "^0.4.1"
+    "uglify-js": "^2.4.14"
   },
   "devDependencies": {
     "mocha": "^1.18.2",


### PR DESCRIPTION
For activate socket.io compatibility in production mode, or with multiple clusters, set `clusterSticky` to `true` in your config file. 