### PR TITLE
Fixes #94 - modules walking code should check for the type correctly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ By "committing" to this file, you ("you" or "You") hereby grant to Linnovate and
 
 You, the contributor agree to the following…
 
-1. That you are the sole owner of the Contributions and/or have sufficient rights in your Contribution to grant all rights you grant hereunder. 
+1. That you are the sole owner of the Contributions and/or have sufficient rights in your Contribution to grant all rights you grant hereunder.
 1. That the Contributions are your original works of authorship.
 1. That you created the Contributions and did not copy them from another source, and no other person claims, or has the right to claim, any right in any invention or patent related to the Contributions.
 1. That you are legally entitled to grant the above license. (If your employer has rights to intellectual property that you create, you represent that you have received permission to make the Contributions on behalf of that employer, or that your employer has waived such rights for the Contributions.)
@@ -35,7 +35,8 @@ If you become aware of any facts or circumstances related to the representation 
 * Taylor Thomas {thomastaylor312}
 * David Büttner {zloKOMAtic}
 * Andrija Petrovic {andrija-hers}
-* John Morris {spxis} 
+* John Morris {spxis}
 * Liran Tal {lirantal}
 * Farhad Adeli {Exlord}
 * Rommel Juarez {juarez9j}
+* David Dasenbrook {sometea}

--- a/lib/core_modules/module/util.js
+++ b/lib/core_modules/module/util.js
@@ -16,10 +16,12 @@ function walk(wpath, type, excludeDir, callback) {
   fs.readdirSync(wpath).forEach(function(file) {
     var newPath = path.join(wpath, file);
     var stat = fs.statSync(newPath);
-    if (stat.isFile() && (rgx.test(file) || (baseRgx.test(file)) && ~newPath.indexOf(type))) {
+    if (stat.isFile() && (rgx.test(file) || (baseRgx.test(file)) &&
+                          ~newPath.split(path.sep).indexOf(type+'s'))) {
       // if (!rgx.test(file)) console.log('  Consider updating filename:', newPath);
       callback(newPath);
-    } else if (stat.isDirectory() && file !== excludeDir && ~newPath.indexOf(type)) {
+    } else if (stat.isDirectory() && file !== excludeDir &&
+               ~newPath.split(path.sep).indexOf(type+'s')) {
       walk(newPath, type, excludeDir, callback);
     }
   });


### PR DESCRIPTION
As described in #94, if the path of the app has the substring "model" in it, the app crashes. This was because when loading mean.io modules, the code walking through the directory and loading the modules just checked the type by searching for the substring in the path, causing controllers to be loaded before the modules. This PR fixes the issue by changing the way the type is checked.

See also linnovate/mean#1283