### PR TITLE
generic events implementation. disables stacksight.

### DIFF
--- a/lib/core_modules/events/events.js
+++ b/lib/core_modules/events/events.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var EventEmitter = require('events');
+var util = require('util');
+
+function MyEmitter() {
+  EventEmitter.call(this);
+}
+
+util.inherits(MyEmitter, EventEmitter);
+
+var myEmitter = new MyEmitter();
+
+
+function Events(module) {
+    this._default = {};
+}
+
+Events.prototype.publish = function(opts) {
+    if (!opts) return;
+
+    for (var index in this._default)
+        opts[index] = opts[index] || this._default[index];
+
+    if (opts.action) {
+        myEmitter.emit(opts.action, opts);
+    }
+    else {
+        myEmitter.emit(opts);
+    }
+
+};
+
+Events.prototype.subscribe = function(name, cb) {
+    myEmitter.on(name, cb);
+};
+
+Events.prototype.defaultData = function(data) {
+    for (var index in data) {
+        this._default[index] = data[index];
+    }
+};
+
+module.exports = Events;

--- a/lib/core_modules/module/index.js
+++ b/lib/core_modules/module/index.js
@@ -8,7 +8,7 @@ var Q = require('q'),
   util = require('./util'),
   DependableList = require('./dependablelist'),
   search = require('./search'),
-  Events = require('../sts/events');
+  Events = require('../events/events');
 
 var _modules = new DependableList();
 

--- a/lib/core_modules/server/ExpressEngine.js
+++ b/lib/core_modules/server/ExpressEngine.js
@@ -75,13 +75,6 @@ ExpressEngine.prototype.beginBootstrap = function(meanioinstance, database) {
   };
   this.app = app;
 
-  var sts = require('../sts')(this.app);
-  sts.session.up();
-  sts.events.publish({
-      type: 'session',
-      action: 'started',
-      name: sts.session.name
-  });
 
   // Register app dependency;
   meanioinstance.register('app', this.initApp.bind(this));


### PR DESCRIPTION
Keeping to the standard set before, if an event has an `action`, that is the name of the event. You can also pass a string as the name

Action
```
Articles.events.publish({
    action: 'article:deleted',
    user: {
        name: req.user.name
    },
    name: article.title
});
```

String
```
Articles.events.publish('article:deleted');
```

Subscribing:
`PackageName.events.subscribe('article:deleted', function(){console.log('event fired')});`

Fixes #96