### PR TITLE
wildcard event support with EventEmitter2 + remove sts

### DIFF
--- a/lib/core_modules/events/events.js
+++ b/lib/core_modules/events/events.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var EventEmitter2 = require('eventemitter2').EventEmitter2;
+var emitter = new EventEmitter2({
+  wildcard: true,
+  delimiter: '.',
+  // set this to `true` if you want to emit the newListener event. The default value is `true`
+  newListener: true,
+  // the maximum amount of listeners that can be assigned to an event, default 10.
+  maxListeners: 20
+});
+
+
+function Events(module) {
+    this._default = {};
+}
+
+Events.prototype.publish = function(opts) {
+    if (!opts) return;
+    // Grab event type and other defaults from the package
+    for (var index in this._default) {
+      if (this._default.hasOwnProperty(index)){
+        opts[index] = opts[index] || this._default[index];
+      }
+    }
+    if (!opts.type) {
+      console.log('Error: events require a "type" property')
+      return;
+    }
+    if (!opts.action) {
+      console.log('Error: events require an "action" property')
+      return;
+    }
+    emitter.emit([opts.type, opts.action], opts);
+};
+
+Events.prototype.subscribe = function(name, cb) {
+    emitter.on(name, cb);
+};
+
+/**
+ * Fires on any event
+ * @param  {Function} cb function(event, value)
+ */
+Events.prototype.onAny = function(cb) {
+    emitter.onAny(cb);
+};
+
+Events.prototype.defaultData = function(data) {
+    for (var index in data) {
+        this._default[index] = data[index];
+    }
+};
+
+module.exports = Events;

--- a/lib/core_modules/module/index.js
+++ b/lib/core_modules/module/index.js
@@ -8,7 +8,7 @@ var Q = require('q'),
   util = require('./util'),
   DependableList = require('./dependablelist'),
   search = require('./search'),
-  Events = require('../sts/events');
+  Events = require('../events/events');
 
 var _modules = new DependableList();
 

--- a/lib/core_modules/server/ExpressEngine.js
+++ b/lib/core_modules/server/ExpressEngine.js
@@ -75,13 +75,6 @@ ExpressEngine.prototype.beginBootstrap = function(meanioinstance, database) {
   };
   this.app = app;
 
-  var sts = require('../sts')(this.app);
-  sts.session.up();
-  sts.events.publish({
-      type: 'session',
-      action: 'started',
-      name: sts.session.name
-  });
 
   // Register app dependency;
   meanioinstance.register('app', this.initApp.bind(this));

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "complex-list": "latest",
     "dependable-list": "latest",
     "express-jwt": "latest",
+    "eventemitter2": "1.0.0",
     "glob": "^4.0.3",
     "lazy-dependable": "latest",
     "lodash": "^2.4.1",


### PR DESCRIPTION
Adds wilcard event support with [EventEmitter2](https://github.com/asyncly/EventEmitter2)
Removes STS.

Wildcard events let you match all events from a particular package:

```
Package.events.subscribe('user.*, function(event){
  console.log(event);
});
```
Where `user` is the type set in app.js
```
MeanUser.events.defaultData({
  type: 'user'
});
```

You can also listen to ALL events with `onAny`:
```
Package.events.onAny(function(event, value){
  console.log('This will log ALL events from any package, be careful!', event, value);
});
```

I removed sts and added a generic events implementation for 0.9.0, but imho this is more powerful and should be the default for both the current branch and 0.9.0