### PR TITLE
rename read only prototype property

### DIFF
--- a/lib/core_modules/server/ExpressEngine.js
+++ b/lib/core_modules/server/ExpressEngine.js
@@ -31,7 +31,7 @@ ExpressEngine.prototype.destroy = function(){
   this.app = null;
   ServerEngine.prototype.destroy.call(this);
 };
-ExpressEngine.prototype.name = function(){
+ExpressEngine.prototype.engineName = function(){
   return 'express';
 };
 ExpressEngine.prototype.initApp = function() {


### PR DESCRIPTION
```
TypeError: Cannot assign to read only property 'name' of [object Object]
    at Object.<anonymous> (/app/node_modules/meanio/lib/core_modules/server/ExpressEngine.js:38:30)
```

This came up on Node > 7.